### PR TITLE
feat(vcard): preserve types, structured ORG/N, add UID

### DIFF
--- a/app/vcards.py
+++ b/app/vcards.py
@@ -1,5 +1,6 @@
 import vobject, re
-from typing import List, Dict
+from typing import List, Dict, Optional, TypedDict
+from uuid import uuid4
 
 CRLF = "\r\n"
 
@@ -17,13 +18,76 @@ def _escape(s: str) -> str:
 essential_fields = ("fn", "email_list", "tel_list", "org")
 
 def parse_vcards(text: str) -> List[Dict]:
-    contacts = []
+    """Parse vCard text into a normalized contact dict list.
+
+    Output shape per contact:
+      {
+        name: Optional[str]  # FN if present
+        n: {
+          family: str, given: str, additional: str, prefix: str, suffix: str
+        } | None
+        emails: List[{ value: str, types: List[str] }]
+        phones: List[{ value: str, types: List[str] }]
+        org: List[str] | None  # structured components
+      }
+    """
+    contacts: List[Dict] = []
     for v in vobject.readComponents(text):
+        # FN and structured N
+        fn_val: Optional[str] = getattr(v, 'fn', None).value if hasattr(v, 'fn') else None
+        n_struct = None
+        if hasattr(v, 'n') and getattr(v, 'n', None) is not None:
+            nval = v.n.value  # vobject.vcard.Name
+            n_struct = {
+                "family": nval.family or "",
+                "given": nval.given or "",
+                "additional": nval.additional or "",
+                "prefix": nval.prefix or "",
+                "suffix": nval.suffix or "",
+            }
+        else:
+            # Derive a minimal N from FN as best-effort
+            if fn_val:
+                parts = str(fn_val).strip().split()
+                if len(parts) >= 2:
+                    n_struct = {"family": " ".join(parts[1:]), "given": parts[0], "additional": "", "prefix": "", "suffix": ""}
+                else:
+                    n_struct = {"family": "", "given": parts[0] if parts else "", "additional": "", "prefix": "", "suffix": ""}
+
+        # Emails with types
+        emails = []
+        for e in getattr(v, 'email_list', []):
+            types = e.params.get('TYPE', []) if hasattr(e, 'params') else []
+            # vobject may provide a single string or list
+            if isinstance(types, str):
+                types = [types]
+            emails.append({"value": e.value, "types": [str(t).lower() for t in types]})
+
+        # Phones with types
+        phones = []
+        for p in getattr(v, 'tel_list', []):
+            types = p.params.get('TYPE', []) if hasattr(p, 'params') else []
+            if isinstance(types, str):
+                types = [types]
+            phones.append({"value": p.value, "types": [str(t).lower() for t in types]})
+
+        # ORG structured components
+        org_list = None
+        if hasattr(v, 'org') and v.org is not None:
+            try:
+                # Typically a list of components
+                vals = v.org.value or []
+                org_list = [str(x) for x in vals]
+            except Exception:
+                # fallback: treat as a single string
+                org_list = [str(v.org.value)]
+
         c = {
-            "name": getattr(v, 'fn', None).value if hasattr(v, 'fn') else None,
-            "emails": [e.value for e in getattr(v, 'email_list', [])],
-            "phones": [p.value for p in getattr(v, 'tel_list', [])],
-            "org": v.org.value[0] if hasattr(v, 'org') else None,
+            "name": fn_val,
+            "n": n_struct,
+            "emails": emails,
+            "phones": phones,
+            "org": org_list,
         }
         contacts.append(c)
     return contacts
@@ -34,18 +98,45 @@ def contact_to_vcard40(c: Dict) -> str:
         "BEGIN:VCARD",
         "VERSION:4.0",
     ]
+    # FN
     name = c.get("name") or "Unnamed"
-    props.append(f"N:;{_escape(name)};;;")
+    # N (structured): family;given;additional;prefix;suffix
+    n_struct = c.get("n") or {"family": "", "given": name, "additional": "", "prefix": "", "suffix": ""}
+    n_fields = [
+        _escape(n_struct.get("family", "")),
+        _escape(n_struct.get("given", "")),
+        _escape(n_struct.get("additional", "")),
+        _escape(n_struct.get("prefix", "")),
+        _escape(n_struct.get("suffix", "")),
+    ]
+    props.append("N:" + ";".join(n_fields))
     props.append(f"FN:{_escape(name)}")
+
+    # EMAIL
     for e in c.get("emails", []):
-        props.append(f"EMAIL:{_escape(e)}")
+        types = e.get("types", [])
+        type_param = f";TYPE={','.join(sorted(set(t for t in types if t)))}" if types else ""
+        props.append(f"EMAIL{type_param}:{_escape(e.get('value',''))}")
+
+    # TEL (VALUE=uri tel:...)
     for p in c.get("phones", []):
-        tel = re.sub(r"\s+", "", str(p))
+        tel_raw = str(p.get("value", ""))
+        tel = re.sub(r"\s+", "", tel_raw)
         if not tel.startswith("tel:"):
             tel = f"tel:{tel}"
-        props.append(f"TEL;TYPE=cell;VALUE=uri:{_escape(tel)}")
+        types = p.get("types", [])
+        type_param = f";TYPE={','.join(sorted(set(t for t in types if t)))}" if types else ""
+        props.append(f"TEL{type_param};VALUE=uri:{_escape(tel)}")
+
+    # ORG structured
     if c.get("org"):
-        props.append(f"ORG:{_escape(c['org'])}")
+        comps = [
+            _escape(str(comp)) for comp in (c.get("org") or [])
+        ]
+        props.append("ORG:" + ";".join(comps))
+
+    # UID
+    props.append(f"UID:{uuid4()}")
     props.append("END:VCARD")
     return CRLF.join(props) + CRLF
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 vobject==0.9.7
 jinja2==3.1.4
+python-multipart==0.0.9

--- a/tests/test_vcards.py
+++ b/tests/test_vcards.py
@@ -1,0 +1,30 @@
+import re
+from app.vcards import parse_vcards, contacts_to_vcards40
+
+SAMPLE = (
+    "BEGIN:VCARD\r\n"
+    "VERSION:3.0\r\n"
+    "N:Doe;John;;;\r\n"
+    "FN:John Doe\r\n"
+    "TEL;TYPE=CELL,HOME: +1 555 0100\r\n"
+    "EMAIL;TYPE=WORK:john.doe@example.com\r\n"
+    "ORG:Acme;Sales\r\n"
+    "END:VCARD\r\n"
+)
+
+def test_parse_and_serialize_types_and_org():
+    contacts = parse_vcards(SAMPLE)
+    assert len(contacts) == 1
+    c = contacts[0]
+    assert c["n"]["family"] == "Doe"
+    assert c["n"]["given"] == "John"
+    assert c["org"] == ["Acme", "Sales"]
+    # Serialize
+    out = contacts_to_vcards40(contacts)
+    assert "VERSION:4.0" in out
+    # TEL carries TYPEs and VALUE=uri (allow CRLF)
+    assert re.search(r"^TEL;TYPE=cell,home;VALUE=uri:tel:\+15550100\r?$", out, re.M)
+    # EMAIL TYPE=work (allow CRLF)
+    assert re.search(r"^EMAIL;TYPE=work:john.doe@example.com\r?$", out, re.M)
+    # UID present (allow CRLF)
+    assert re.search(r"^UID:[0-9a-fA-F-]{36}\r?$", out, re.M)


### PR DESCRIPTION
- Parse TEL/EMAIL types and emit TYPE params in vCard 4.0\n- Preserve structured ORG; improve N generation\n- Add UID to each card\n- Add pytest covering types/ORG/N/UID\n\nThis is PR 1 of 3.